### PR TITLE
Update the dependency graph representations

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -55,7 +55,6 @@ impl<R: io::BufRead> ReadSentence for Reader<R> {
         let mut line = String::new();
         let mut sentence = Sentence::new();
         let mut edges = Vec::new();
-        let mut proj_edges = Vec::new();
 
         loop {
             line.clear();
@@ -66,7 +65,7 @@ impl<R: io::BufRead> ReadSentence for Reader<R> {
                     return Ok(None);
                 }
 
-                add_edges(&mut sentence, edges, proj_edges);
+                add_edges(&mut sentence, edges);
 
                 return Ok(Some(sentence));
             }
@@ -79,7 +78,7 @@ impl<R: io::BufRead> ReadSentence for Reader<R> {
                     continue;
                 }
 
-                add_edges(&mut sentence, edges, proj_edges);
+                add_edges(&mut sentence, edges);
 
                 return Ok(Some(sentence));
             }
@@ -104,33 +103,14 @@ impl<R: io::BufRead> ReadSentence for Reader<R> {
                 edges.push(DepTriple::new(head, head_rel, sentence.len()));
             }
 
-            // Projective head relation.
-            if let Some(proj_head) = parse_numeric_field(iter.next())? {
-                let proj_head_rel = parse_string_field(iter.next());
-                proj_edges.push(DepTriple::new(proj_head, proj_head_rel, sentence.len()));
-            }
-
-            //token.set_head();
-            //token.set_head_rel();
-            //token.set_p_head(parse_numeric_field(iter.next())?);
-            //token.set_p_head_rel(parse_string_field(iter.next()));
-
             sentence.push(token);
         }
     }
 }
 
-fn add_edges(
-    sentence: &mut Sentence,
-    edges: Vec<DepTriple<String>>,
-    proj_edges: Vec<DepTriple<String>>,
-) {
+fn add_edges(sentence: &mut Sentence, edges: Vec<DepTriple<String>>) {
     for edge in edges {
         sentence.dep_graph_mut().add_deprel(edge);
-    }
-
-    for edge in proj_edges {
-        sentence.proj_dep_graph_mut().add_deprel(edge);
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -39,8 +39,6 @@ lazy_static! {
             .add_deprel(DepTriple::new(2, Some("DET"), 1));
         s1.dep_graph_mut()
             .add_deprel(DepTriple::new(0, Some("ROOT"), 2));
-        s1.proj_dep_graph_mut()
-            .add_deprel(DepTriple::new(0, Some("TEST"), 1));
 
         sentences.push(s1);
 

--- a/testdata/empty.conll
+++ b/testdata/empty.conll
@@ -1,4 +1,4 @@
-1	Die	die	ART	ART	case=nominative|gender=feminine|number=singular	2	DET	0	TEST
+1	Die	die	ART	ART	case=nominative|gender=feminine|number=singular	2	DET	_	_
 2	Großaufnahme	Großaufnahme	N	NN	case=nominative|gender=feminine|number=singular	0	ROOT	_	_
 
 1	Gilles	Gilles	N	NE	case=nominative|gender=masculine|number=singular	0	ROOT	_	_


### PR DESCRIPTION
- CoNLL-U does not store a (separate) projective graph.
- Prepare the graph representation for supporting enhanced
  dependencies.