### PR TITLE
Add handling for DEPS and MISC fields

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -213,7 +213,7 @@ impl Display for Sentence {
 
             writeln!(
                 fmt,
-                "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t_\t_",
+                "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
                 i,
                 token.form(),
                 token.lemma().unwrap_or("_"),
@@ -225,6 +225,11 @@ impl Display for Sentence {
                     .unwrap_or_else(|| "_".to_string()),
                 head.unwrap_or_else(|| "_".to_string()),
                 head_rel.unwrap_or_else(|| "_".to_string()),
+                token.deps().unwrap_or("_"),
+                token
+                    .misc()
+                    .map(|m| m.join("|"))
+                    .unwrap_or_else(|| "_".to_owned())
             )?;
         }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -103,6 +103,13 @@ impl<R: io::BufRead> ReadSentence for Reader<R> {
                 edges.push(DepTriple::new(head, head_rel, sentence.len()));
             }
 
+            token.set_deps(parse_string_field(iter.next()));
+
+            token.set_misc(
+                parse_string_field(iter.next())
+                    .map(|s| s.split('|').map(ToOwned::to_owned).collect::<Vec<String>>()),
+            );
+
             sentence.push(token);
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -21,6 +21,8 @@ lazy_static! {
                 .features(
                     Features::try_from("case=nominative|gender=feminine|number=singular").unwrap(),
                 )
+                .deps("2:det")
+                .misc(vec!["misc1".to_string(), "misc2".to_string()])
                 .into(),
         );
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -60,6 +60,18 @@ impl TokenBuilder {
         self.token.set_features(Some(features));
         self
     }
+
+    #[allow(dead_code)]
+    pub(crate) fn deps(mut self, deps: impl Into<String>) -> TokenBuilder {
+        self.token.set_deps(Some(deps.into()));
+        self
+    }
+
+    /// Set the additional information associated with the token.
+    pub fn misc(mut self, misc: Vec<String>) -> TokenBuilder {
+        self.token.set_misc(Some(misc));
+        self
+    }
 }
 
 impl From<Token> for TokenBuilder {
@@ -81,6 +93,11 @@ pub struct Token {
     upos: Option<String>,
     xpos: Option<String>,
     features: Option<Features>,
+    misc: Option<Vec<String>>,
+
+    // Currently not exposed, but stored to preserve existing
+    // field on read -> write round trips.
+    deps: Option<String>,
 }
 
 impl Token {
@@ -92,6 +109,8 @@ impl Token {
             upos: None,
             xpos: None,
             features: None,
+            misc: None,
+            deps: None,
         }
     }
 
@@ -125,6 +144,22 @@ impl Token {
     /// Returns a mutable reference, so that the features can be updated.
     pub fn features_mut(&mut self) -> Option<&mut Features> {
         self.features.as_mut()
+    }
+
+    pub(crate) fn deps(&self) -> Option<&str> {
+        self.deps.as_deref()
+    }
+
+    /// Get the additional information associated with the token.
+    pub fn misc(&self) -> Option<&[String]> {
+        self.misc.as_deref()
+    }
+
+    /// Get the additional information associated with the token.
+    ///
+    /// Returns a mutable reference, so that the information can be updated.
+    pub fn misc_mut(&mut self) -> Option<&mut Vec<String>> {
+        self.misc.as_mut()
     }
 
     /// Set the word form or punctuation symbol.
@@ -169,6 +204,17 @@ impl Token {
     /// Returns the features that are replaced.
     pub fn set_features(&mut self, features: Option<Features>) -> Option<Features> {
         mem::replace(&mut self.features, features)
+    }
+
+    pub(crate) fn set_deps(&mut self, deps: Option<impl Into<String>>) -> Option<String> {
+        mem::replace(&mut self.deps, deps.map(Into::into))
+    }
+
+    /// Set the additional information associated with the token.
+    ///
+    /// Returns the information that is replaced.
+    pub fn set_misc(&mut self, misc: Option<impl Into<Vec<String>>>) -> Option<Vec<String>> {
+        mem::replace(&mut self.misc, misc.map(Into::into))
     }
 }
 

--- a/testdata/basic.conll
+++ b/testdata/basic.conll
@@ -1,4 +1,4 @@
-1	Die	die	ART	ART	case=nominative|gender=feminine|number=singular	2	DET	0	TEST
+1	Die	die	ART	ART	case=nominative|gender=feminine|number=singular	2	DET	2:det	misc1|misc2
 2	Großaufnahme	Großaufnahme	N	NN	case=nominative|gender=feminine|number=singular	0	ROOT
 
 1	Gilles	Gilles	N	NE	case=nominative|gender=masculine|number=singular	0	ROOT

--- a/testdata/double-newline.conll
+++ b/testdata/double-newline.conll
@@ -1,4 +1,4 @@
-1	Die	die	ART	ART	case=nominative|gender=feminine|number=singular	2	DET	0	TEST
+1	Die	die	ART	ART	case=nominative|gender=feminine|number=singular	2	DET	2:det	misc1|misc2
 2	Großaufnahme	Großaufnahme	N	NN	case=nominative|gender=feminine|number=singular	0	ROOT
 
 

--- a/testdata/empty.conll
+++ b/testdata/empty.conll
@@ -1,4 +1,4 @@
-1	Die	die	ART	ART	case=nominative|gender=feminine|number=singular	2	DET	_	_
+1	Die	die	ART	ART	case=nominative|gender=feminine|number=singular	2	DET	2:det	misc1|misc2
 2	Großaufnahme	Großaufnahme	N	NN	case=nominative|gender=feminine|number=singular	0	ROOT	_	_
 
 1	Gilles	Gilles	N	NE	case=nominative|gender=masculine|number=singular	0	ROOT	_	_


### PR DESCRIPTION
- For DEPS, we do not provide a public API (yet). However, we do store
  the field as-is to ensure that it is preserved during read-write round
  trips.
- The MISC field is represented as a Vec<String>. Following the
  CoNLL-U description, this field is split on vertical bars (|).