### PR TITLE
Add support for CoNLL-U comments

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,7 +4,7 @@ use std::io::BufReader;
 
 use lazy_static::lazy_static;
 
-use crate::graph::{DepTriple, Sentence};
+use crate::graph::{Comment, DepTriple, Sentence};
 use crate::io::{ReadSentence, Reader};
 use crate::token::{Features, TokenBuilder};
 
@@ -13,6 +13,12 @@ lazy_static! {
         let mut sentences = Vec::new();
 
         let mut s1 = Sentence::new();
+        s1.comments_mut().push(Comment::AttrVal {
+            attr: "sent_id".to_string(),
+            val: "1".to_string(),
+        });
+        s1.comments_mut()
+            .push(Comment::String("some random comment".to_string()));
         s1.push(
             TokenBuilder::new("Die")
                 .lemma("die")

--- a/testdata/basic.conll
+++ b/testdata/basic.conll
@@ -1,3 +1,5 @@
+# sent_id = 1
+# some random comment
 1	Die	die	ART	ART	case=nominative|gender=feminine|number=singular	2	DET	2:det	misc1|misc2
 2	Großaufnahme	Großaufnahme	N	NN	case=nominative|gender=feminine|number=singular	0	ROOT
 

--- a/testdata/double-newline.conll
+++ b/testdata/double-newline.conll
@@ -1,3 +1,5 @@
+# sent_id = 1
+# some random comment
 1	Die	die	ART	ART	case=nominative|gender=feminine|number=singular	2	DET	2:det	misc1|misc2
 2	Großaufnahme	Großaufnahme	N	NN	case=nominative|gender=feminine|number=singular	0	ROOT
 

--- a/testdata/empty.conll
+++ b/testdata/empty.conll
@@ -1,3 +1,5 @@
+# sent_id = 1
+# some random comment
 1	Die	die	ART	ART	case=nominative|gender=feminine|number=singular	2	DET	2:det	misc1|misc2
 2	Großaufnahme	Großaufnahme	N	NN	case=nominative|gender=feminine|number=singular	0	ROOT	_	_
 


### PR DESCRIPTION
Comments are parsed as attribute value pairs if the contain the
separator ` = ` (including the spaces).