### PR TITLE
Model the MISC column as features with optional values

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -304,7 +304,7 @@ impl Display for Sentence {
                 token.deps().unwrap_or("_"),
                 token
                     .misc()
-                    .map(|m| m.join("|"))
+                    .map(Into::into)
                     .unwrap_or_else(|| "_".to_owned())
             )?;
         }

--- a/src/io.rs
+++ b/src/io.rs
@@ -7,7 +7,7 @@ use failure::Error;
 
 use crate::error::ParseError;
 use crate::graph::{Comment, DepTriple, Sentence};
-use crate::token::{Features, Token, EMPTY_TOKEN};
+use crate::token::{Features, Misc, Token, EMPTY_TOKEN};
 
 /// A trait for objects that can read CoNLL-U `Sentence`s
 pub trait ReadSentence {
@@ -110,10 +110,7 @@ impl<R: io::BufRead> ReadSentence for Reader<R> {
 
             token.set_deps(parse_string_field(iter.next()));
 
-            token.set_misc(
-                parse_string_field(iter.next())
-                    .map(|s| s.split('|').map(ToOwned::to_owned).collect::<Vec<String>>()),
-            );
+            token.set_misc(parse_string_field(iter.next()).map(|s| Misc::from(s.as_str())));
 
             sentence.push(token);
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,12 +1,13 @@
 use std::convert::TryFrom;
 use std::fs::File;
 use std::io::BufReader;
+use std::iter::FromIterator;
 
 use lazy_static::lazy_static;
 
 use crate::graph::{Comment, DepTriple, Sentence};
 use crate::io::{ReadSentence, Reader};
-use crate::token::{Features, TokenBuilder};
+use crate::token::{Features, Misc, TokenBuilder};
 
 lazy_static! {
     pub static ref TEST_SENTENCES: Vec<Sentence> = {
@@ -28,7 +29,10 @@ lazy_static! {
                     Features::try_from("case=nominative|gender=feminine|number=singular").unwrap(),
                 )
                 .deps("2:det")
-                .misc(vec!["misc1".to_string(), "misc2".to_string()])
+                .misc(Misc::from_iter(vec![
+                    ("misc1", None),
+                    ("misc2", Some("value")),
+                ]))
                 .into(),
         );
 

--- a/testdata/basic.conll
+++ b/testdata/basic.conll
@@ -1,6 +1,6 @@
 # sent_id = 1
 # some random comment
-1	Die	die	ART	ART	case=nominative|gender=feminine|number=singular	2	DET	2:det	misc1|misc2
+1	Die	die	ART	ART	case=nominative|gender=feminine|number=singular	2	DET	2:det	misc1|misc2=value
 2	Großaufnahme	Großaufnahme	N	NN	case=nominative|gender=feminine|number=singular	0	ROOT
 
 1	Gilles	Gilles	N	NE	case=nominative|gender=masculine|number=singular	0	ROOT

--- a/testdata/double-newline.conll
+++ b/testdata/double-newline.conll
@@ -1,6 +1,6 @@
 # sent_id = 1
 # some random comment
-1	Die	die	ART	ART	case=nominative|gender=feminine|number=singular	2	DET	2:det	misc1|misc2
+1	Die	die	ART	ART	case=nominative|gender=feminine|number=singular	2	DET	2:det	misc1|misc2=value
 2	Großaufnahme	Großaufnahme	N	NN	case=nominative|gender=feminine|number=singular	0	ROOT
 
 

--- a/testdata/empty.conll
+++ b/testdata/empty.conll
@@ -1,6 +1,6 @@
 # sent_id = 1
 # some random comment
-1	Die	die	ART	ART	case=nominative|gender=feminine|number=singular	2	DET	2:det	misc1|misc2
+1	Die	die	ART	ART	case=nominative|gender=feminine|number=singular	2	DET	2:det	misc1|misc2=value
 2	Großaufnahme	Großaufnahme	N	NN	case=nominative|gender=feminine|number=singular	0	ROOT	_	_
 
 1	Gilles	Gilles	N	NE	case=nominative|gender=masculine|number=singular	0	ROOT	_	_


### PR DESCRIPTION
According to the CoNLL-U specification:

"The exact format used in this field should be specified in the
treebank-specific documentation, but it has to be formatted as a list
that can be split on the vertical bar character (|)."

Moreover, it seems to be quite common to put feature-value pairs in
this column, separated by `=`.

This change represents the MISC column as a mapping, where:

- List values without an equals sign are stored as: (value, None)
- List values with an equals sign are stored as: (key, Some(value)