### PR TITLE
Token: do not wrap `features` and `misc` in `Option`

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -295,17 +295,11 @@ impl Display for Sentence {
                 token.lemma().unwrap_or("_"),
                 token.upos().unwrap_or("_"),
                 token.xpos().unwrap_or("_"),
-                token
-                    .features()
-                    .map(Into::into)
-                    .unwrap_or_else(|| "_".to_string()),
+                String::from(token.features()),
                 head.unwrap_or_else(|| "_".to_string()),
                 head_rel.unwrap_or_else(|| "_".to_string()),
                 token.deps().unwrap_or("_"),
-                token
-                    .misc()
-                    .map(Into::into)
-                    .unwrap_or_else(|| "_".to_owned())
+                String::from(token.misc())
             )?;
         }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -99,7 +99,8 @@ impl<R: io::BufRead> ReadSentence for Reader<R> {
             token.set_features(
                 parse_string_field(iter.next())
                     .map(|s| Features::try_from(s.as_str()))
-                    .transpose()?,
+                    .transpose()?
+                    .unwrap_or_else(Features::new),
             );
 
             // Head relation.
@@ -110,7 +111,11 @@ impl<R: io::BufRead> ReadSentence for Reader<R> {
 
             token.set_deps(parse_string_field(iter.next()));
 
-            token.set_misc(parse_string_field(iter.next()).map(|s| Misc::from(s.as_str())));
+            token.set_misc(
+                parse_string_field(iter.next())
+                    .map(|s| Misc::from(s.as_str()))
+                    .unwrap_or_else(Misc::new),
+            );
 
             sentence.push(token);
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -7,7 +7,7 @@ use lazy_static::lazy_static;
 
 use crate::graph::{Comment, DepTriple, Sentence};
 use crate::io::{ReadSentence, Reader};
-use crate::token::{Features, Misc, TokenBuilder};
+use crate::token::{Features, Misc, Token, TokenBuilder};
 
 lazy_static! {
     pub static ref TEST_SENTENCES: Vec<Sentence> = {
@@ -80,6 +80,12 @@ lazy_static! {
         s2.dep_graph_mut()
             .add_deprel(DepTriple::new(1, Some("APP"), 2));
         sentences.push(s2);
+
+        let mut s3 = Sentence::new();
+        s3.push(Token::new("Plain"));
+        s3.push(Token::new("and"));
+        s3.push(Token::new("simple"));
+        sentences.push(s3);
 
         sentences
     };

--- a/testdata/basic.conll
+++ b/testdata/basic.conll
@@ -5,3 +5,7 @@
 
 1	Gilles	Gilles	N	NE	case=nominative|gender=masculine|number=singular	0	ROOT
 2	Deleuze	Deleuze	N	NE	case=nominative|number=singular|gender=masculine	1	APP
+
+1	Plain
+2	and
+3	simple

--- a/testdata/double-newline.conll
+++ b/testdata/double-newline.conll
@@ -6,3 +6,8 @@
 
 1	Gilles	Gilles	N	NE	case=nominative|gender=masculine|number=singular	0	ROOT
 2	Deleuze	Deleuze	N	NE	case=nominative|number=singular|gender=masculine	1	APP
+
+
+1	Plain	_	_	_	_	_	_	_	_
+2	and	_	_	_	_	_	_	_	_
+3	simple	_	_	_	_	_	_	_	_

--- a/testdata/empty.conll
+++ b/testdata/empty.conll
@@ -5,3 +5,7 @@
 
 1	Gilles	Gilles	N	NE	case=nominative|gender=masculine|number=singular	0	ROOT	_	_
 2	Deleuze	Deleuze	N	NE	case=nominative|gender=masculine|number=singular	1	APP	_	_
+
+1	Plain	_	_	_	_	_	_	_	_
+2	and	_	_	_	_	_	_	_	_
+3	simple	_	_	_	_	_	_	_	_


### PR DESCRIPTION
For these fields, the absence of morphological features and misc
features can be represented using an empty map.