### PR TITLE
Redo error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ exclude = [
 ]
 
 [dependencies]
-failure = "0.1"
 itertools = "0.8"
 petgraph = "0.4"
+thiserror = "1"
 
 [dev-dependencies]
 lazy_static = "1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,29 +1,43 @@
-use failure::Fail;
+use std::io;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum IOError {
+    #[error("error reading treebank")]
+    IO(#[from] io::Error),
+
+    #[error(transparent)]
+    Parse(#[from] ParseError),
+}
 
 /// CoNLL-U parsing errors.
-#[derive(Debug, Eq, Fail, PartialEq)]
+#[derive(Debug, Error, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum ParseError {
     /// The form is missing in the CoNLL-U data.
-    #[fail(display = "form field is missing")]
+    #[error("form field is missing")]
     MissingFormField,
 
     /// The feature field could not be parsed
-    #[fail(display = "cannot parse feature field: {}", value)]
+    #[error("cannot parse feature field: {value:?}")]
     IncorrectFeatureField { value: String },
 
     /// An integer field could not be parsed as an integer.
-    #[fail(display = "cannot parse as integer field: {}", value)]
+    #[error("cannot parse as integer field: {value:?}")]
     ParseIntField { value: String },
 
     /// The identifier field could not be parsed.
-    #[fail(display = "cannot parse as identifier field: {}", value)]
+    #[error("cannot parse as identifier field: {value:?})")]
     ParseIdentifierField { value: String },
 }
 
 /// Graph errors.
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum GraphError {
     /// The graph is missing relevant information.
-    #[fail(display = "incomplete graph: {}", value)]
+    #[error("incomplete graph: {value:?}")]
     IncompleteGraph { value: String },
 }


### PR DESCRIPTION
- Use `thiserror` to deriver `Error` on the error types.
- Return concrete errors and not `failure::Error`.