### PR TITLE
Fix parsing after empty head

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -105,6 +105,9 @@ impl<R: io::BufRead> ReadSentence for Reader<R> {
             if let Some(head) = parse_numeric_field(iter.next())? {
                 let head_rel = parse_string_field(iter.next());
                 edges.push(DepTriple::new(head, head_rel, sentence.len()));
+            } else {
+                // Skip the head releation if we don't have a dependency relation field.
+                iter.next();
             }
 
             token.set_deps(parse_string_field(iter.next()));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -63,6 +63,7 @@ lazy_static! {
                 .features(
                     Features::try_from("case=nominative|gender=masculine|number=singular").unwrap(),
                 )
+                .misc(Misc::from("NE=per"))
                 .into(),
         );
         s2.push(
@@ -73,6 +74,7 @@ lazy_static! {
                 .features(
                     Features::try_from("case=nominative|gender=masculine|number=singular").unwrap(),
                 )
+                .misc(Misc::from("NE=per"))
                 .into(),
         );
         s2.dep_graph_mut()
@@ -86,6 +88,15 @@ lazy_static! {
         s3.push(Token::new("and"));
         s3.push(Token::new("simple"));
         sentences.push(s3);
+
+        let mut s4 = Sentence::new();
+        s4.push(
+            TokenBuilder::new("Amsterdam")
+                .misc(Misc::from("NE=loc"))
+                .into(),
+        );
+        eprintln!("{:?}", s4);
+        sentences.push(s4);
 
         sentences
     };

--- a/testdata/basic.conll
+++ b/testdata/basic.conll
@@ -3,9 +3,11 @@
 1	Die	die	ART	ART	case=nominative|gender=feminine|number=singular	2	DET	2:det	misc1|misc2=value
 2	Großaufnahme	Großaufnahme	N	NN	case=nominative|gender=feminine|number=singular	0	ROOT
 
-1	Gilles	Gilles	N	NE	case=nominative|gender=masculine|number=singular	0	ROOT
-2	Deleuze	Deleuze	N	NE	case=nominative|number=singular|gender=masculine	1	APP
+1	Gilles	Gilles	N	NE	case=nominative|gender=masculine|number=singular	0	ROOT	_	NE=per
+2	Deleuze	Deleuze	N	NE	case=nominative|number=singular|gender=masculine	1	APP	_	NE=per
 
 1	Plain
 2	and
 3	simple
+
+1	Amsterdam	_	_	_	_	_	_	_	NE=loc

--- a/testdata/double-newline.conll
+++ b/testdata/double-newline.conll
@@ -4,10 +4,13 @@
 2	Großaufnahme	Großaufnahme	N	NN	case=nominative|gender=feminine|number=singular	0	ROOT
 
 
-1	Gilles	Gilles	N	NE	case=nominative|gender=masculine|number=singular	0	ROOT
-2	Deleuze	Deleuze	N	NE	case=nominative|number=singular|gender=masculine	1	APP
+1	Gilles	Gilles	N	NE	case=nominative|gender=masculine|number=singular	0	ROOT	_	NE=per
+2	Deleuze	Deleuze	N	NE	case=nominative|number=singular|gender=masculine	1	APP	_	NE=per
 
 
 1	Plain	_	_	_	_	_	_	_	_
 2	and	_	_	_	_	_	_	_	_
 3	simple	_	_	_	_	_	_	_	_
+
+
+1	Amsterdam	_	_	_	_	_	_	_	NE=loc

--- a/testdata/empty.conll
+++ b/testdata/empty.conll
@@ -3,9 +3,11 @@
 1	Die	die	ART	ART	case=nominative|gender=feminine|number=singular	2	DET	2:det	misc1|misc2=value
 2	Großaufnahme	Großaufnahme	N	NN	case=nominative|gender=feminine|number=singular	0	ROOT	_	_
 
-1	Gilles	Gilles	N	NE	case=nominative|gender=masculine|number=singular	0	ROOT	_	_
-2	Deleuze	Deleuze	N	NE	case=nominative|gender=masculine|number=singular	1	APP	_	_
+1	Gilles	Gilles	N	NE	case=nominative|gender=masculine|number=singular	0	ROOT	_	NE=per
+2	Deleuze	Deleuze	N	NE	case=nominative|gender=masculine|number=singular	1	APP	_	NE=per
 
 1	Plain	_	_	_	_	_	_	_	_
 2	and	_	_	_	_	_	_	_	_
 3	simple	_	_	_	_	_	_	_	_
+
+1	Amsterdam	_	_	_	_	_	_	_	NE=loc


### PR DESCRIPTION
All columns shifted by one when the head field is empty, because the
dependency relation was not parsed.