### PR TITLE
Reject dependency relations without a head

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -31,6 +31,10 @@ pub enum ParseError {
     /// The identifier field could not be parsed.
     #[error("cannot parse as identifier field: {value:?})")]
     ParseIdentifierField { value: String },
+
+    /// Dependency relation without a head.
+    #[error("dependency relation without a head: {token:?}")]
+    RelationWithoutHead { token: String },
 }
 
 /// Graph errors.


### PR DESCRIPTION
We (currently) have no way of representing dependency relations
without a head. In such cases the dependency relations were silently
lost in a read/write roundtrip.

With this change we reject tokens that have a dependency relation
without a head. If this occurs in real data, it is more likely to be
an error than anything else.