### PR TITLE
DepGraphMut.add_deprel: return error when head/dep is out-of-bounds

### DIFF
--- a/conllu/src/error.rs
+++ b/conllu/src/error.rs
@@ -1,6 +1,7 @@
 use std::io;
 
 use thiserror::Error;
+use udgraph::error::GraphError;
 
 /// CoNLL-U IO error.
 #[derive(Debug, Error)]
@@ -19,6 +20,10 @@ pub enum IOError {
 #[derive(Debug, Error, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ParseError {
+    /// Error construction the graph.
+    #[error(transparent)]
+    Parse(#[from] GraphError),
+
     /// The form is missing in the CoNLL-U data.
     #[error("form field is missing")]
     MissingFormField,

--- a/conllu/src/tests.rs
+++ b/conllu/src/tests.rs
@@ -58,9 +58,11 @@ lazy_static! {
         );
 
         s1.dep_graph_mut()
-            .add_deprel(DepTriple::new(2, Some("DET"), 1));
+            .add_deprel(DepTriple::new(2, Some("DET"), 1))
+            .unwrap();
         s1.dep_graph_mut()
-            .add_deprel(DepTriple::new(0, Some("ROOT"), 2));
+            .add_deprel(DepTriple::new(0, Some("ROOT"), 2))
+            .unwrap();
 
         sentences.push(s1);
 
@@ -98,9 +100,11 @@ lazy_static! {
                 .into(),
         );
         s2.dep_graph_mut()
-            .add_deprel(DepTriple::new(0, Some("ROOT"), 1));
+            .add_deprel(DepTriple::new(0, Some("ROOT"), 1))
+            .unwrap();
         s2.dep_graph_mut()
-            .add_deprel(DepTriple::new(1, Some("APP"), 2));
+            .add_deprel(DepTriple::new(1, Some("APP"), 2))
+            .unwrap();
         sentences.push(s2);
 
         let mut s3 = Sentence::new();

--- a/conllu/testdata/incorrect-head.conll
+++ b/conllu/testdata/incorrect-head.conll
@@ -1,0 +1,13 @@
+# sent_id = 1
+# some random comment
+1	Die	die	ART	ART	case=nominative|gender=feminine|number=singular	2	DET	2:det	misc1|misc2=value
+2	Großaufnahme	Großaufnahme	N	NN	case=nominative|gender=feminine|number=singular	0	ROOT
+
+1	Gilles	Gilles	N	NE	case=nominative|gender=masculine|number=singular	0	ROOT	_	NE=per
+2	Deleuze	Deleuze	N	NE	case=nominative|number=singular|gender=masculine	3	APP	_	NE=per
+
+1	Plain
+2	and
+3	simple
+
+1	Amsterdam	_	_	_	_	_	_	_	NE=loc

--- a/udgraph-projectivize/src/proj.rs
+++ b/udgraph-projectivize/src/proj.rs
@@ -52,7 +52,7 @@ impl HeadProjectivizer {
                 .expect("Endpoints of lifted edge could not be found");
 
             if let Some(new_head) =
-                self.search_attachment_point(&graph, cur_head, *lifted_node, pref_head_rel)
+                self.search_attachment_point(graph, cur_head, *lifted_node, pref_head_rel)
             {
                 let head_rel = graph
                     .remove_edge(head_edge)

--- a/udgraph/Cargo.toml
+++ b/udgraph/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 
 [dependencies]
 petgraph = { version = "0.6", default-features = false }
+thiserror = "1"
 
 [dev-dependencies]
 lazy_static = "1"

--- a/udgraph/src/error.rs
+++ b/udgraph/src/error.rs
@@ -1,0 +1,12 @@
+use thiserror::Error;
+
+/// Graph processing error.
+#[derive(Debug, Error, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum GraphError {
+    #[error("dependent {dependent:?} is out of bounds for graph with {node_count:?} vertices")]
+    DependentOutOfBounds { dependent: usize, node_count: usize },
+
+    #[error("head {head:?} is out of bounds for graph with {node_count:?} vertices")]
+    HeadOutOfBounds { head: usize, node_count: usize },
+}

--- a/udgraph/src/lib.rs
+++ b/udgraph/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod error;
+
 pub mod graph;
 
 pub mod token;

--- a/udgraph/src/tests.rs
+++ b/udgraph/src/tests.rs
@@ -55,9 +55,11 @@ lazy_static! {
         );
 
         s1.dep_graph_mut()
-            .add_deprel(DepTriple::new(2, Some("DET"), 1));
+            .add_deprel(DepTriple::new(2, Some("DET"), 1))
+            .unwrap();
         s1.dep_graph_mut()
-            .add_deprel(DepTriple::new(0, Some("ROOT"), 2));
+            .add_deprel(DepTriple::new(0, Some("ROOT"), 2))
+            .unwrap();
 
         sentences.push(s1);
 
@@ -95,9 +97,11 @@ lazy_static! {
                 .into(),
         );
         s2.dep_graph_mut()
-            .add_deprel(DepTriple::new(0, Some("ROOT"), 1));
+            .add_deprel(DepTriple::new(0, Some("ROOT"), 1))
+            .unwrap();
         s2.dep_graph_mut()
-            .add_deprel(DepTriple::new(1, Some("APP"), 2));
+            .add_deprel(DepTriple::new(1, Some("APP"), 2))
+            .unwrap();
         sentences.push(s2);
 
         let mut s3 = Sentence::new();

--- a/udgraph/src/token.rs
+++ b/udgraph/src/token.rs
@@ -385,7 +385,7 @@ impl<'a> Iterator for TokenIter<'a> {
     type Item = &'a Token;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(node) = self.inner.next() {
+        for node in self.inner.by_ref() {
             if let Node::Token(token) = node {
                 return Some(token);
             }
@@ -404,7 +404,7 @@ impl<'a> Iterator for TokenIterMut<'a> {
     type Item = &'a mut Token;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(node) = self.inner.next() {
+        for node in self.inner.by_ref() {
             if let Node::Token(token) = node {
                 return Some(token);
             }


### PR DESCRIPTION
- DepGraphMut.add_deprel: return error when head/dep is out-of-bounds
- Add clippy fixes
