### PR TITLE
Name all crate-level error types `Error`

### DIFF
--- a/conllu/src/error.rs
+++ b/conllu/src/error.rs
@@ -1,12 +1,9 @@
 use std::io;
 
-use thiserror::Error;
-use udgraph::error::GraphError;
-
 /// CoNLL-U IO error.
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
-pub enum IOError {
+pub enum Error {
     /// Error in file IO.
     #[error("error reading treebank")]
     IO(#[from] io::Error),
@@ -17,12 +14,12 @@ pub enum IOError {
 }
 
 /// CoNLL-U parsing errors.
-#[derive(Debug, Error, Eq, PartialEq)]
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ParseError {
     /// Error construction the graph.
     #[error(transparent)]
-    Parse(#[from] GraphError),
+    Parse(#[from] udgraph::Error),
 
     /// The form is missing in the CoNLL-U data.
     #[error("form field is missing")]

--- a/conllu/src/lib.rs
+++ b/conllu/src/lib.rs
@@ -1,7 +1,7 @@
 //! Traits to read/write `udgraph` graphs from CoNLL-U format.
 
 mod error;
-pub use crate::error::{IOError, ParseError};
+pub use crate::error::{Error, ParseError};
 
 pub mod io;
 

--- a/udgraph-projectivize/src/error.rs
+++ b/udgraph-projectivize/src/error.rs
@@ -1,9 +1,7 @@
-use thiserror::Error;
-
 /// Graph errors.
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
-pub enum ProjectivizeError {
+pub enum Error {
     /// The graph is missing relevant information.
     #[error("incomplete graph: {value:?}")]
     IncompleteGraph { value: String },

--- a/udgraph-projectivize/src/lib.rs
+++ b/udgraph-projectivize/src/lib.rs
@@ -1,5 +1,5 @@
 mod error;
-pub use error::ProjectivizeError;
+pub use error::Error;
 
 mod graph_algo;
 pub(crate) use crate::graph_algo::BfsWithDepth;

--- a/udgraph-projectivize/src/proj.rs
+++ b/udgraph-projectivize/src/proj.rs
@@ -7,17 +7,17 @@ use itertools::Itertools;
 use petgraph::graph::{node_index, EdgeIndex, NodeIndex};
 use petgraph::visit::{Bfs, EdgeRef, NodeFiltered, Walker};
 use petgraph::{Directed, Direction, Graph};
-use udgraph::error::GraphError;
 use udgraph::graph::{DepTriple, Sentence};
+use udgraph::Error as UDError;
 
-use crate::{BfsWithDepth, ProjectivizeError};
+use crate::{BfsWithDepth, Error};
 
 pub trait Deprojectivize {
-    fn deprojectivize(&self, sentence: &mut Sentence) -> Result<(), ProjectivizeError>;
+    fn deprojectivize(&self, sentence: &mut Sentence) -> Result<(), Error>;
 }
 
 pub trait Projectivize {
-    fn projectivize(&self, sentence: &mut Sentence) -> Result<(), ProjectivizeError>;
+    fn projectivize(&self, sentence: &mut Sentence) -> Result<(), Error>;
 }
 
 /// A projectivizer using the 'head' marking strategy. See: *Pseudo-Projective
@@ -188,7 +188,7 @@ impl Default for HeadProjectivizer {
 }
 
 impl Projectivize for HeadProjectivizer {
-    fn projectivize(&self, sentence: &mut Sentence) -> Result<(), ProjectivizeError> {
+    fn projectivize(&self, sentence: &mut Sentence) -> Result<(), Error> {
         let mut graph = simplify_graph(sentence)?;
         let mut lifted = HashSet::new();
 
@@ -217,7 +217,7 @@ impl Projectivize for HeadProjectivizer {
 }
 
 impl Deprojectivize for HeadProjectivizer {
-    fn deprojectivize(&self, sentence: &mut Sentence) -> Result<(), ProjectivizeError> {
+    fn deprojectivize(&self, sentence: &mut Sentence) -> Result<(), Error> {
         let graph = simplify_graph(sentence)?;
 
         // Find nodes and corresponding edges that are lifted and remove
@@ -253,9 +253,7 @@ impl Deprojectivize for HeadProjectivizer {
     }
 }
 
-pub fn simplify_graph(
-    sentence: &Sentence,
-) -> Result<Graph<(), String, Directed>, ProjectivizeError> {
+pub fn simplify_graph(sentence: &Sentence) -> Result<Graph<(), String, Directed>, Error> {
     let mut edges = Vec::with_capacity(sentence.len() + 1);
     for idx in 0..sentence.len() {
         let triple = match sentence.dep_graph().head(idx) {
@@ -266,7 +264,7 @@ pub fn simplify_graph(
         let head_rel = match triple.relation() {
             Some(head_rel) => head_rel,
             None => {
-                return Err(ProjectivizeError::IncompleteGraph {
+                return Err(Error::IncompleteGraph {
                     value: format!(
                         "edge from {} to {} does not have a label",
                         triple.head(),
@@ -326,7 +324,7 @@ pub fn non_projective_edges(graph: &Graph<(), String, Directed>) -> Vec<EdgeInde
 fn update_sentence(
     graph: &Graph<(), String, Directed>,
     sentence: &mut Sentence,
-) -> Result<(), GraphError> {
+) -> Result<(), UDError> {
     let mut sent_graph = sentence.dep_graph_mut();
     for edge_ref in graph.edge_references() {
         sent_graph.add_deprel(DepTriple::new(

--- a/udgraph/src/error.rs
+++ b/udgraph/src/error.rs
@@ -1,9 +1,7 @@
-use thiserror::Error;
-
 /// Graph processing error.
-#[derive(Debug, Error, Eq, PartialEq)]
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
 #[non_exhaustive]
-pub enum GraphError {
+pub enum Error {
     #[error("dependent {dependent:?} is out of bounds for graph with {node_count:?} vertices")]
     DependentOutOfBounds { dependent: usize, node_count: usize },
 

--- a/udgraph/src/graph.rs
+++ b/udgraph/src/graph.rs
@@ -10,7 +10,7 @@ use petgraph::graph::{node_index, DiGraph, NodeIndices, NodeWeightsMut};
 use petgraph::visit::EdgeRef;
 use petgraph::Direction;
 
-use crate::error::GraphError;
+use crate::error::Error;
 use crate::token::Token;
 
 /// Dependency graph node.
@@ -446,19 +446,19 @@ impl<'a> DepGraphMut<'a> {
     ///
     /// If `dependent` already has a head relation, this relation is removed
     /// to ensure single-headedness.
-    pub fn add_deprel<S>(&mut self, triple: DepTriple<S>) -> Result<(), GraphError>
+    pub fn add_deprel<S>(&mut self, triple: DepTriple<S>) -> Result<(), Error>
     where
         S: Into<String>,
     {
         if triple.head() >= self.inner.node_count() {
-            return Err(GraphError::HeadOutOfBounds {
+            return Err(Error::HeadOutOfBounds {
                 head: triple.head(),
                 node_count: self.inner.node_count(),
             });
         }
 
         if triple.dependent() >= self.inner.node_count() {
-            return Err(GraphError::DependentOutOfBounds {
+            return Err(Error::DependentOutOfBounds {
                 dependent: triple.head(),
                 node_count: self.inner.node_count(),
             });

--- a/udgraph/src/lib.rs
+++ b/udgraph/src/lib.rs
@@ -1,4 +1,5 @@
-pub mod error;
+mod error;
+pub use error::Error;
 
 pub mod graph;
 


### PR DESCRIPTION
Also expose them at the top level of the crate.
